### PR TITLE
chore: update download urls

### DIFF
--- a/powershell_files/function_definitions.ps1
+++ b/powershell_files/function_definitions.ps1
@@ -5,8 +5,8 @@ $cmder_unpack_path = Join-Path $env:USERPROFILE "cmder/"
 
 # Paths only needed by download script
 $zip_temp = Join-Path $project_root "temp.zip"
-$download_cmder_url = "https://github.com/cmderdev/cmder/releases/download/v1.3.12/cmder.zi"
-$download_make_url = "https://sourceforge.net/projects/ezwinports/files/make-4.2.1-without-guile-w32-bin.zip/downloa"
+$download_cmder_url = "https://github.com//cmderdev/cmder/releases/download/v1.3.13/cmder.zip"
+$download_make_url = "https://sourceforge.net/projects/ezwinports/files/make-4.2.1-without-guile-w32-bin.zip/download"
 $cmder_executable_path = Join-Path $cmder_unpack_path "Cmder.exe"
 $cmder_executable_path_escaped = "$([RegEx]::Escape($cmder_unpack_path))Cmder.exe"
 $make_unpack_path = Join-Path $project_root "make/"


### PR DESCRIPTION
## Base PullRequest

default branch (https://github.com/s-weigand/get-cmder/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>python .github/update_tools/update_downloads.py</em></summary>

```Shell
Replacing cmderr_download_url
Replacing make_download_url
Writing changes to /home/runner/work/get-cmder/get-cmder/powershell_files/function_definitions.ps1
```

### stderr:

```Shell
[W:pyppeteer.chromium_downloader] start chromium download.
Download may take a few minutes.
  0%|          | 0/106826418 [00:00<?, ?it/s]  1%|          | 808960/106826418 [00:00<00:13, 7986555.39it/s]  2%|▏         | 2129920/106826418 [00:00<00:11, 9051574.15it/s]  4%|▍         | 4147200/106826418 [00:00<00:09, 10829219.32it/s]  7%|▋         | 7280640/106826418 [00:00<00:07, 13464980.31it/s] 11%|█▏        | 12042240/106826418 [00:00<00:05, 17149633.74it/s] 18%|█▊        | 19384320/106826418 [00:00<00:03, 22269731.23it/s] 28%|██▊       | 30228480/106826418 [00:00<00:02, 29238704.47it/s] 45%|████▌     | 48537600/106826418 [00:00<00:01, 39092866.99it/s] 67%|██████▋   | 71587840/106826418 [00:00<00:00, 52060355.95it/s] 90%|████████▉ | 96143360/106826418 [00:01<00:00, 68173515.11it/s]100%|██████████| 106826418/106826418 [00:01<00:00, 101862082.13it/s]
[W:pyppeteer.chromium_downloader] 
chromium download done.
[W:pyppeteer.chromium_downloader] chromium extracted to: /home/runner/.local/share/pyppeteer/local-chromium/575458
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- powershell_files/function_definitions.ps1

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)