### PR TITLE
chore: update download urls

### DIFF
--- a/powershell_files/function_definitions.ps1
+++ b/powershell_files/function_definitions.ps1
@@ -5,7 +5,7 @@ $cmder_unpack_path = Join-Path $env:USERPROFILE "cmder/"
 
 # Paths only needed by download script
 $zip_temp = Join-Path $project_root "temp.zip"
-$download_cmder_url = "https://github.com//cmderdev/cmder/releases/download/v1.3.13/cmder.zi"
+$download_cmder_url = "https://github.com//cmderdev/cmder/releases/download/v1.3.13/cmder.zip"
 $download_make_url = "https://sourceforge.net/projects/ezwinports/files/make-4.2.1-without-guile-w32-bin.zip/download"
 $cmder_executable_path = Join-Path $cmder_unpack_path "Cmder.exe"
 $cmder_executable_path_escaped = "$([RegEx]::Escape($cmder_unpack_path))Cmder.exe"


### PR DESCRIPTION
## Base PullRequest

default branch (https://github.com/s-weigand/get-cmder/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>python .github/update_tools/update_downloads.py</em></summary>

```Shell
Replacing cmderr_download_url with: https://github.com//cmderdev/cmder/releases/download/v1.3.13/cmder.zip
Writing changes to /home/runner/work/get-cmder/get-cmder/powershell_files/function_definitions.ps1
```

### stderr:

```Shell
[W:pyppeteer.chromium_downloader] start chromium download.
Download may take a few minutes.
  0%|          | 0/106826418 [00:00<?, ?it/s]  1%|          | 808960/106826418 [00:00<00:13, 8075879.32it/s]  2%|▏         | 2150400/106826418 [00:00<00:11, 9157391.20it/s]  4%|▍         | 4311040/106826418 [00:00<00:09, 11048122.78it/s]  7%|▋         | 7751680/106826418 [00:00<00:07, 13869342.41it/s] 12%|█▏        | 13240320/106826418 [00:00<00:05, 17870463.46it/s] 20%|██        | 21391360/106826418 [00:00<00:03, 23335660.81it/s] 32%|███▏      | 34662400/106826418 [00:00<00:02, 31000032.67it/s] 52%|█████▏    | 55633920/106826418 [00:00<00:01, 41646740.84it/s] 74%|███████▍  | 79063040/106826418 [00:00<00:00, 55282911.44it/s] 97%|█████████▋| 103475200/106826418 [00:01<00:00, 71988146.23it/s]100%|██████████| 106826418/106826418 [00:01<00:00, 105143541.36it/s]
[W:pyppeteer.chromium_downloader] 
chromium download done.
[W:pyppeteer.chromium_downloader] chromium extracted to: /home/runner/.local/share/pyppeteer/local-chromium/575458
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- powershell_files/function_definitions.ps1

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)