### PR TITLE
chore: update download urls

### DIFF
--- a/powershell_files/function_definitions.ps1
+++ b/powershell_files/function_definitions.ps1
@@ -5,7 +5,7 @@ $cmder_unpack_path = Join-Path $env:USERPROFILE "cmder/"
 
 # Paths only needed by download script
 $zip_temp = Join-Path $project_root "temp.zip"
-$download_cmder_url = "https://github.com//cmderdev/cmder/releases/download/v1.3.13/cmder.zip"
+$download_cmder_url = "https://github.com//cmderdev/cmder/releases/download/v1.3.14/cmder.zip"
 $download_make_url = "https://sourceforge.net/projects/ezwinports/files/make-4.2.1-without-guile-w32-bin.zip/download"
 $cmder_executable_path = Join-Path $cmder_unpack_path "Cmder.exe"
 $cmder_executable_path_escaped = "$([RegEx]::Escape($cmder_unpack_path))Cmder.exe"


### PR DESCRIPTION
## Base PullRequest

default branch (https://github.com/s-weigand/get-cmder/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>python .github/update_tools/update_downloads.py</em></summary>

```Shell
Replacing cmderr_download_url with: https://github.com//cmderdev/cmder/releases/download/v1.3.14/cmder.zip
Writing changes to /home/runner/work/get-cmder/get-cmder/powershell_files/function_definitions.ps1
```

### stderr:

```Shell
[W:pyppeteer.chromium_downloader] start chromium download.
Download may take a few minutes.
  0%|          | 0/106826418 [00:00<?, ?it/s] 11%|█▏        | 12134400/106826418 [00:00<00:00, 121322710.77it/s] 19%|█▉        | 20172800/106826418 [00:00<00:00, 105127437.65it/s] 24%|██▎       | 25169920/106826418 [00:00<00:01, 63980705.00it/s]  38%|███▊      | 41082880/106826418 [00:00<00:00, 77927313.94it/s] 46%|████▌     | 48977920/106826418 [00:00<00:00, 73732180.19it/s] 55%|█████▍    | 58726400/106826418 [00:00<00:00, 71466988.75it/s] 71%|███████   | 75499520/106826418 [00:00<00:00, 78375427.68it/s] 82%|████████▏ | 87910400/106826418 [00:00<00:00, 88116264.58it/s] 91%|█████████ | 97310720/106826418 [00:01<00:00, 88757650.18it/s]100%|█████████▉| 106598400/106826418 [00:01<00:00, 85234608.32it/s]100%|██████████| 106826418/106826418 [00:01<00:00, 88492952.42it/s]
[W:pyppeteer.chromium_downloader] 
chromium download done.
[W:pyppeteer.chromium_downloader] chromium extracted to: /home/runner/.local/share/pyppeteer/local-chromium/575458
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- powershell_files/function_definitions.ps1

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)