### PR TITLE
⬆️ Update download urls

### DIFF
--- a/powershell_files/function_definitions.ps1
+++ b/powershell_files/function_definitions.ps1
@@ -5,8 +5,8 @@ $cmder_unpack_path = Join-Path $env:USERPROFILE "cmder/"
 
 # Paths only needed by download script
 $zip_temp = Join-Path $project_root "temp.zip"
-$download_cmder_url = "https://github.com/cmderdev/cmder/releases/download/v1.3.21/cmder.zip"
-$download_make_url = "https://sourceforge.net/projects/ezwinports/files/make-4.4-without-guile-w32-bin.zip/download"
+$download_cmder_url = "https://github.com/cmderdev/cmder/releases/download/v1.3.24/cmder.zip"
+$download_make_url = "https://sourceforge.net/projects/ezwinports/files/make-4.4.1-without-guile-w32-bin.zip/download"
 $cmder_executable_path = Join-Path $cmder_unpack_path "Cmder.exe"
 $cmder_executable_path_escaped = "$([RegEx]::Escape($cmder_unpack_path))Cmder.exe"
 $make_unpack_path = Join-Path $project_root "make/"


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/get-cmder/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>python .github/update_tools/update_downloads.py</em></summary>

```Shell
Replacing cmderr_download_url with: https://github.com/cmderdev/cmder/releases/download/v1.3.24/cmder.zip
Replacing make_download_url with: https://sourceforge.net/projects/ezwinports/files/make-4.4.1-without-guile-w32-bin.zip/download
Writing changes to /home/runner/work/get-cmder/get-cmder/powershell_files/function_definitions.ps1
```

### stderr:

```Shell
[INFO] Starting Chromium download.
  0%|          | 0.00/109M [00:00<?, ?b/s] 10%|█         | 11.0M/109M [00:00<00:00, 107Mb/s] 28%|██▊       | 30.9M/109M [00:00<00:00, 161Mb/s] 48%|████▊     | 52.4M/109M [00:00<00:00, 185Mb/s] 69%|██████▉   | 75.0M/109M [00:00<00:00, 201Mb/s] 88%|████████▊ | 95.2M/109M [00:00<00:00, 201Mb/s]100%|██████████| 109M/109M [00:00<00:00, 196Mb/s] 
[INFO] Beginning extraction
[INFO] Chromium extracted to: /home/runner/.local/share/pyppeteer/local-chromium/588429
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- powershell_files/function_definitions.ps1

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)